### PR TITLE
Remove unsafe and direct use of openssl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.12"
 flate2 = "1.0"
 chrono = "0.4"
-openssl = "0.10"
-openssl-sys = "0.9"
+openssl = "0.10.32"
 foreign-types = "0.3.1"
 
 [dev-dependencies]

--- a/src/jwk/alg/ecx.rs
+++ b/src/jwk/alg/ecx.rs
@@ -77,8 +77,8 @@ impl EcxKeyPair {
     pub fn generate(curve: EcxCurve) -> Result<EcxKeyPair, JoseError> {
         (|| -> anyhow::Result<EcxKeyPair> {
             let private_key = match curve {
-                EcxCurve::X25519 => openssl_ecx::generate_x25519()?,
-                EcxCurve::X448 => openssl_ecx::generate_x448()?,
+                EcxCurve::X25519 => PKey::generate_x25519()?,
+                EcxCurve::X448 => PKey::generate_x448()?,
             };
 
             Ok(EcxKeyPair {
@@ -532,66 +532,5 @@ mod tests {
 
         let data = fs::read(&pb)?;
         Ok(data)
-    }
-}
-
-mod openssl_ecx {
-    use openssl::error::ErrorStack;
-    use openssl::pkey::{PKey, Private};
-    use openssl_sys::{
-        i2d_PrivateKey, EVP_PKEY_CTX_free, EVP_PKEY_CTX_new_id, EVP_PKEY_free, EVP_PKEY_keygen,
-        EVP_PKEY_keygen_init,
-    };
-    use std::os::raw::c_int;
-    use std::ptr;
-
-    const NID_X25519: c_int = 1034;
-    const NID_X448: c_int = 1035;
-
-    pub(crate) fn generate_x25519() -> Result<PKey<Private>, ErrorStack> {
-        generate_der(NID_X25519)
-    }
-
-    pub(crate) fn generate_x448() -> Result<PKey<Private>, ErrorStack> {
-        generate_der(NID_X448)
-    }
-
-    fn generate_der(nid: c_int) -> Result<PKey<Private>, ErrorStack> {
-        let der = unsafe {
-            let pctx = match EVP_PKEY_CTX_new_id(nid, ptr::null_mut()) {
-                val if val.is_null() => return Err(ErrorStack::get()),
-                val => val,
-            };
-
-            if EVP_PKEY_keygen_init(pctx) <= 0 {
-                EVP_PKEY_CTX_free(pctx);
-                return Err(ErrorStack::get());
-            }
-
-            let mut pkey = ptr::null_mut();
-            if EVP_PKEY_keygen(pctx, &mut pkey) <= 0 {
-                EVP_PKEY_CTX_free(pctx);
-                return Err(ErrorStack::get());
-            }
-
-            let len = match i2d_PrivateKey(pkey, ptr::null_mut()) {
-                val if val <= 0 => {
-                    EVP_PKEY_free(pkey);
-                    return Err(ErrorStack::get());
-                }
-                val => val,
-            };
-
-            let mut der = vec![0; len as usize];
-            if i2d_PrivateKey(pkey, &mut der.as_mut_ptr()) != len {
-                EVP_PKEY_free(pkey);
-                return Err(ErrorStack::get());
-            }
-
-            EVP_PKEY_free(pkey);
-            der
-        };
-
-        PKey::private_key_from_der(&der)
     }
 }


### PR DESCRIPTION
I recently started using josekit for a project, and I was very impressed by the project, also considering it's developed by one person.

I noticed that the project contains a very small amount of unsafe, and I saw that the main problem was related to the openssl crate not exposing some APIs. I decided to [implement the missing pieces](https://github.com/sfackler/rust-openssl/pull/1384), and recently the new version of the `openssl` crate has been published, making these new APIs available for josekit.

I based my work on `openssl` on your work on `josekit`, so I did nothing more than creating an abstraction layer over your code. With this PR, `josekit` is 100% safe code, which is always a nice feature to have.

Let me know if you like this.
Thank you for efforts you put into this crate! :heart: 