### PR TITLE
Add Debug to JoseHeader

### DIFF
--- a/src/jose_header.rs
+++ b/src/jose_header.rs
@@ -1,6 +1,6 @@
 use crate::Value;
 
-pub trait JoseHeader: Send + Sync {
+pub trait JoseHeader: Send + Sync + std::fmt::Debug {
     // Return claim count.
     fn len(&self) -> usize;
 


### PR DESCRIPTION
This tells the compiler that all implementations of JoseHeader will
implement Debug, which means that trait objects can be debug-printed.