### PR TITLE
Allow De/Serialization of JWK Keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1"
 anyhow = "1"
 once_cell = "1"
 regex = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.13"
 flate2 = "1"

--- a/src/jwk/jwk.rs
+++ b/src/jwk/jwk.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use std::fmt::Display;
 use std::io::Read;
 use std::string::ToString;
@@ -12,8 +14,9 @@ use crate::util;
 use crate::{JoseError, Map, Value};
 
 /// Represents JWK object.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct Jwk {
+    #[serde(flatten)]
     map: Map<String, Value>,
 }
 


### PR DESCRIPTION
`josekit::jwk::Jwk` is now able to be serialized and deserialized as a transparent representation of the underlying map.

I need to be able to write and read JWK keys to/from disk in a keyring and serve the public JWK keys over HTTP, similar to [how Google serves their public keys in JWK format](https://www.googleapis.com/oauth2/v3/certs):

<details>
<summary>Google JWK Keys</summary>

```json
{
  "keys": [
    {
      "e": "AQAB",
      "alg": "RS256",
      "kty": "RSA",
      "use": "sig",
      "kid": "33ff5af12d7666c58f9956e65e46c9c02ef8e742",
      "n": "tQSZmOenF0ffW7BrOzL8u4r5XH0xsI3QpFYvVSCFWrBiPWDPVjfssA6uoGI6sn3aw810Er6Atv2BjeUvrFeMLkFwuRRFyE95aCSx0s-hDNtXsIOvX7LcJgQn3F3gVUPUvQDfL40DnMq0CWWpNCxNggBdok4emegiQO-C4J7aKy_ACcznsmMVtABvJDM_KpayIfWQfujsfQ8x0pggoxfPIopZLzZaMq8teEYcpVzbNvMyMopNMNPvnKMe56O_Clf_3HQBQtovHYCOK33mJmx4u1aijRMIfgoJYdVA26raLYx5_gNu_De9VWyrvknNwCSYtS0t7xIqzH2oiKtGiM9nJw"
    },
    {
      "n": "wsM16HUl8VtOHqW-QT_k4fe67AsHPZfB05aUSIiSdPOBONDrAq7ylsVOzKRVOuCVwwmLTDL3k6fBFRYDMmhmo28AKkD6AtDA9qqkuXAovA0TFeeQ_WDHlpstE-ZgTPyykIyoG0lIMtdaZ7wKAoNv75QhtI_PAjtmJ4lCa_xx258rxr1-E8ZvUlT2I5gh_vLqYpsRuWX6uZ5Dl5SILPJuwBdfD-PIvgBGEDHT2ZpKR_IoxLNZDR7WtR6xCTiqrPj0SbMOOpyN7G28jH_jJfdw-9CD5AbWN7BlDmJU-oKcgUTee9lZLuYIPy1J7LtAac4MnGMGbupmPOQ1jzAaMpStrw",
      "kid": "ca00620c5aa7be8cd03a6f3c68406e45e93b3cab",
      "use": "sig",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB"
    }
  ]
}
```

</details>

This is essentially the following:

```rust
#[derive(Serialize)]
pub struct JwkKeys {
    pub keys: Vec<Jwk>,
}
```

Making `Jwk` serializable and deserializable makes it trivial for users to save/load JWK keys for a variety of uses.