### PR TITLE
Fix for x5u, x5c implementation error

### DIFF
--- a/src/jws/jws_header.rs
+++ b/src/jws/jws_header.rs
@@ -148,7 +148,7 @@ impl JwsHeader {
         for val in values {
             vec.push(Value::String(base64::encode_config(
                 val.as_ref(),
-                base64::URL_SAFE_NO_PAD,
+                base64::STANDARD_NO_PAD,
             )));
         }
         self.claims.insert(key.to_string(), Value::Array(vec));
@@ -162,7 +162,7 @@ impl JwsHeader {
                 for val in vals {
                     match val {
                         Value::String(val2) => {
-                            match base64::decode_config(val2, base64::URL_SAFE_NO_PAD) {
+                            match base64::decode_config(val2, base64::STANDARD_NO_PAD) {
                                 Ok(val3) => vec.push(val3.clone()),
                                 Err(_) => return None,
                             }


### PR DESCRIPTION
Fixes set_x509_certificate_chain() and x509_certificate_chain() implementation error.

Per RFC 7515, 4.1.6 (https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6) each string entry in the x5c header parameter is a "base64-encoded (Section 4 of [RFC4648] -- not base64url-encoded) DER [ITU.X690.2008] PKIX certificate value."