### PR TITLE
Remove patch version for openssl to allow for RUSTSEC-2024-0357 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.21"
 flate2 = "1"
-openssl = "0.10.62"
+openssl = "0.10"
 time = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Removes the minor version pinning for [openssl](https://github.com/openssl/openssl) to allow users to resolve https://rustsec.org/advisories/RUSTSEC-2024-0357