### PR TITLE
Fix empty payload handling to return empty string instead of {}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 [features]
 default = []
 vendored = ["openssl/vendored"]
+support-empty-payload = []
 
 [dependencies]
 thiserror = "1"

--- a/src/jwt/jwt_context.rs
+++ b/src/jwt/jwt_context.rs
@@ -84,7 +84,11 @@ impl JwtContext {
                 }
             }
 
-            let payload_bytes = serde_json::to_vec(payload.claims_set()).unwrap();
+            let payload_bytes  = if payload.claims_set().is_empty() && cfg!(feature = "support-empty-payload") {
+                Vec::new()
+            } else {
+                serde_json::to_vec(payload.claims_set()).unwrap()
+            };
             let jwt = self
                 .jws_context
                 .serialize_compact(&payload_bytes, header, signer)?;


### PR DESCRIPTION
## Description
Updated the logic to ensure that when the payload is empty, it returns an empty string ("") instead of an empty object ({}).

## Motivation
I am using the josekit library to encrypt HTTP payloads. For GET requests, where the payload is empty, using JwtPayload::new() results in '{}' as the payload. However, in my use case, I need it to be an empty string ("").