### PR TITLE
Fix parsing of RSS-PSS keys from OpenSSL

### DIFF
--- a/src/jwk/alg/rsapss.rs
+++ b/src/jwk/alg/rsapss.rs
@@ -495,6 +495,15 @@ impl RsaPssKeyPair {
                                 _ => break,
                             }
 
+                            match reader.peek() {
+                                Ok(Some(DerType::Null)) => {
+                                    // Skip NULL
+                                    let _ = reader.next();
+                                }
+                                Ok(Some(DerType::EndOfContents)) => {}
+                                _ => break,
+                            }
+
                             match reader.next() {
                                 Ok(Some(DerType::EndOfContents)) => {}
                                 _ => break,
@@ -541,6 +550,15 @@ impl RsaPssKeyPair {
                                     }
                                     _ => return None,
                                 },
+                                _ => break,
+                            }
+
+                            match reader.peek() {
+                                Ok(Some(DerType::Null)) => {
+                                    // Skip NULL
+                                    let _ = reader.next();
+                                }
+                                Ok(Some(DerType::EndOfContents)) => {}
                                 _ => break,
                             }
 


### PR DESCRIPTION
Currently loading an RsaPssKeyPair from a PEM created by OpenSSL 3.4 as per the command in the readme fails with `InvalidKeyFormat(The MGF1 hash algorithm is mismatched: SHA-1)`

```
$ openssl genpkey -algorithm RSA-PSS -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_pss_keygen_md:sha256 -pkeyopt rsa_pss_keygen_mgf1_md:sha256 -pkeyopt rsa_pss_keygen_saltlen:32 -out private.pem
```

This is because OpenSSL inserts NULLs in between `privateKeyAlgorithm` SEQUENCE entries in the generated PEM

<img width="712" alt="image" src="https://github.com/user-attachments/assets/cdafba83-dc84-4ac2-88e1-fd2b4b5fbdae" />

Hence `detect_pkcs8` fails to determine the correct algorithm for the MGF1 parameter.

This PR adds support for these optional NULLs to fix signing and verification with `PS*` key types.
